### PR TITLE
Make the library no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 // This function is non-inline to prevent the optimizer from looking inside it.
 #[inline(never)]
 fn constant_time_ne(a: &[u8], b: &[u8]) -> u8 {


### PR DESCRIPTION
Hi!

When trying to use the [`blake2`](https://crates.io/crates/blake2) crate in `no_std` mode I realized that it actually imports `std` because this crate isn't `no_std` (see RustCrypto/hashes/issues/36). I added a one line change to fix that. Thanks!