### PR TITLE
[ON HOLD FOR A WHILE] Refactor to use a ConstantTimeEq trait with const generics

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "constant_time_eq"
-version = "0.1.5"
+version = "0.2.0"
 authors = ["Cesar Eduardo Barros <cesarb@cesarb.eti.br>"]
 description = "Compares two equal-sized byte strings in constant time."
 documentation = "https://docs.rs/constant_time_eq"
@@ -9,6 +9,10 @@ readme = "README"
 keywords = ["constant_time"]
 categories = ["cryptography", "no-std"]
 license = "CC0-1.0"
+
+[features]
+default = ["const_generics"]
+const_generics = []
 
 [badges]
 travis-ci = { repository = "cesarb/constant_time_eq" }

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -3,14 +3,12 @@
 extern crate constant_time_eq;
 extern crate test;
 
-use constant_time_eq::constant_time_eq;
-use test::{Bencher, black_box};
+use constant_time_eq::ConstantTimeEq;
+use test::{black_box, Bencher};
 
 fn bench(b: &mut Bencher, left: &[u8], right: &[u8]) {
     b.bytes = (left.len() + right.len()) as u64;
-    b.iter(|| {
-        constant_time_eq(black_box(left), black_box(right))
-    })
+    b.iter(|| black_box(left).constant_time_eq(&black_box(right)))
 }
 
 #[bench]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,45 @@
 #![no_std]
 
-// This function is non-inline to prevent the optimizer from looking inside it.
-#[inline(never)]
-fn constant_time_ne(a: &[u8], b: &[u8]) -> u8 {
-    assert!(a.len() == b.len());
+pub trait ConstantTimeEq<B> {
+    #[doc(hidden)]
+    fn constant_time_ne(&self, other: &B) -> u8;
 
+    /// Compares two equal-sized pieces of data in constant time.
+    /// # Examples
+    ///
+    /// ```rust
+    /// use constant_time_eq::ConstantTimeEq;
+    ///
+    /// let array = &[3; 64];
+    /// assert!(array.constant_time_eq(&[3; 64]));
+    /// assert!(!array.constant_time_eq(&[7; 64]));
+    /// assert!(b"foo".constant_time_eq(b"foo"));
+    /// assert!(!b"foo".constant_time_eq(b"bar"));
+    /// ```
+    fn constant_time_eq(&self, other: &B) -> bool;
+}
+
+#[cfg(feature = "const_generics")]
+impl<const LEN: usize> ConstantTimeEq<[u8; LEN]> for [u8; LEN] {
+    // This function is non-inline to prevent the optimizer from looking inside it.
+    #[inline(never)]
+    fn constant_time_ne(&self, other: &Self) -> u8 {
+        let mut tmp = 0;
+        for i in 0..LEN {
+            tmp |= self[i] ^ other[i];
+        }
+        tmp // The compare with 0 must happen outside this function.
+    }
+
+    fn constant_time_eq(&self, other: &Self) -> bool {
+        self.constant_time_ne(other) == 0
+    }
+}
+
+// This is solely to avoid an extra call to as_ref in ConstantTimeEq<AsRef<[u8]>> for &[u8]
+#[inline(never)]
+fn constant_time_ne_array(a: &[u8], b: &[u8]) -> u8 {
+    assert!(a.len() == b.len());
     // These useless slices make the optimizer elide the bounds checks.
     // See the comment in clone_from_slice() added on Rust commit 6a7bc47.
     let len = a.len();
@@ -18,88 +53,40 @@ fn constant_time_ne(a: &[u8], b: &[u8]) -> u8 {
     tmp // The compare with 0 must happen outside this function.
 }
 
-/// Compares two equal-sized byte strings in constant time.
-///
-/// # Examples
-///
-/// ```
-/// use constant_time_eq::constant_time_eq;
-///
-/// assert!(constant_time_eq(b"foo", b"foo"));
-/// assert!(!constant_time_eq(b"foo", b"bar"));
-/// assert!(!constant_time_eq(b"bar", b"baz"));
-/// # assert!(constant_time_eq(b"", b""));
-///
-/// // Not equal-sized, so won't take constant time.
-/// assert!(!constant_time_eq(b"foo", b""));
-/// assert!(!constant_time_eq(b"foo", b"quux"));
-/// ```
-#[inline]
-pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    a.len() == b.len() && constant_time_ne(a, b) == 0
+impl<B: AsRef<[u8]>> ConstantTimeEq<B> for &[u8] {
+    fn constant_time_ne(&self, other: &B) -> u8 {
+        constant_time_ne_array(self, other.as_ref())
+    }
+
+    fn constant_time_eq(&self, other: &B) -> bool {
+        let b = other.as_ref();
+        self.len() == b.len() && constant_time_ne_array(self, b) == 0
+    }
 }
 
-// Fixed-size variants for the most common sizes.
-
-macro_rules! constant_time_ne_n {
-    ($ne:ident, $n:expr) => {
-        // This function is non-inline to prevent the optimizer from looking inside it.
-        #[inline(never)]
-        fn $ne(a: &[u8; $n], b: &[u8; $n]) -> u8 {
-            let mut tmp = 0;
-            for i in 0..$n {
-                tmp |= a[i] ^ b[i];
+#[cfg(not(feature = "const_generics"))]
+macro_rules! constant_time_impl {
+    ($n:expr) => {
+        impl ConstantTimeEq<[u8; $n]> for [u8; $n] {
+            #[inline(never)]
+            fn constant_time_ne(&self, other: &[u8; $n]) -> u8 {
+                let mut tmp = 0;
+                for i in 0..$n {
+                    tmp |= self[i] ^ other[i];
+                }
+                tmp // The compare with 0 must happen outside this function.
             }
-            tmp // The compare with 0 must happen outside this function.
+
+            fn constant_time_eq(&self, other: &[u8; $n]) -> bool {
+                self.constant_time_ne(other) == 0
+            }
         }
     };
 }
 
-constant_time_ne_n!(constant_time_ne_16, 16);
-constant_time_ne_n!(constant_time_ne_32, 32);
-constant_time_ne_n!(constant_time_ne_64, 64);
-
-/// Compares two 128-bit byte strings in constant time.
-///
-/// # Examples
-///
-/// ```
-/// use constant_time_eq::constant_time_eq_16;
-///
-/// assert!(constant_time_eq_16(&[3; 16], &[3; 16]));
-/// assert!(!constant_time_eq_16(&[3; 16], &[7; 16]));
-/// ```
-#[inline]
-pub fn constant_time_eq_16(a: &[u8; 16], b: &[u8; 16]) -> bool {
-    constant_time_ne_16(a, b) == 0
-}
-
-/// Compares two 256-bit byte strings in constant time.
-///
-/// # Examples
-///
-/// ```
-/// use constant_time_eq::constant_time_eq_32;
-///
-/// assert!(constant_time_eq_32(&[3; 32], &[3; 32]));
-/// assert!(!constant_time_eq_32(&[3; 32], &[7; 32]));
-/// ```
-#[inline]
-pub fn constant_time_eq_32(a: &[u8; 32], b: &[u8; 32]) -> bool {
-    constant_time_ne_32(a, b) == 0
-}
-
-/// Compares two 512-bit byte strings in constant time.
-///
-/// # Examples
-///
-/// ```
-/// use constant_time_eq::constant_time_eq_64;
-///
-/// assert!(constant_time_eq_64(&[3; 64], &[3; 64]));
-/// assert!(!constant_time_eq_64(&[3; 64], &[7; 64]));
-/// ```
-#[inline]
-pub fn constant_time_eq_64(a: &[u8; 64], b: &[u8; 64]) -> bool {
-    constant_time_ne_64(a, b) == 0
-}
+#[cfg(not(feature = "const_generics"))]
+constant_time_impl!(16);
+#[cfg(not(feature = "const_generics"))]
+constant_time_impl!(32);
+#[cfg(not(feature = "const_generics"))]
+constant_time_impl!(64);


### PR DESCRIPTION
# ON HOLD UNTIL EITHER `black_box` or `asm!` IS STABLE

* Bumps version to 0.2.0
* Changed the `constant_time_eq_n` functions to a `ConstantTimeEq` trait
* Adds a `const_generics` feature: when enabled, `ConstantTimeEq` will be implemented on `[u8; N]` (otherwise, it's just implemented on `[u8; 16]`, `[u8; 32]`, `[u8; 64]`, and `AsRef<[u8]>`)
* `ConstantTimeEq` can also compare `&[u8]` and any `AsRef<[u8]>`.

This also reduces the +/- value for longer statically-sized arrays (while keeping the average the same)!

Before (https://github.com/cesarb/constant_time_eq/commit/8db4b026a1936dd0544587546275ce73fff9effa):
```
test bench_16    ... bench:           7 ns/iter (+/- 0) = 4571 MB/s
test bench_4096  ... bench:          70 ns/iter (+/- 0) = 117028 MB/s
test bench_65536 ... bench:       1,265 ns/iter (+/- 40) = 103614 MB/s
```

After (https://github.com/cesarb/constant_time_eq/commit/b9e21e592b9c11a4ba05f7ab368e9c91c5f0ae8d):
```
test bench_16    ... bench:           7 ns/iter (+/- 0) = 4571 MB/s
test bench_4096  ... bench:          70 ns/iter (+/- 0) = 117028 MB/s
test bench_65536 ... bench:       1,265 ns/iter (+/- 8) = 103614 MB/s
```