### PR TITLE
Set rust-version to 1.59

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README"
 keywords = ["constant_time"]
 categories = ["cryptography", "no-std"]
 license = "CC0-1.0"
+rust-version = "1.59"
 
 [dev-dependencies]
 criterion = { version = "0.3", features = ["cargo_bench_support", "html_reports"] }


### PR DESCRIPTION
This version is required for inline assembly.