### PR TITLE
Const generic support: try 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ rust-version = "1.59"
 [dev-dependencies]
 criterion = { version = "0.3", features = ["cargo_bench_support", "html_reports"] }
 
+[features]
+default = ["const-generics"]
+const-generics = []
+
 [[bench]]
 name = "bench"
 harness = false

--- a/src/hide.rs
+++ b/src/hide.rs
@@ -1,0 +1,39 @@
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[inline]
+pub(crate) fn optimizer_hide(mut value: u8) -> u8 {
+    // SAFETY: the input value is passed unchanged to the output, the inline assembly does nothing.
+    unsafe {
+        core::arch::asm!("/* {0} */", inout(reg_byte) value, options(pure, nomem, nostack, preserves_flags));
+        value
+    }
+}
+
+#[cfg(any(
+    target_arch = "arm",
+    target_arch = "aarch64",
+    target_arch = "riscv32",
+    target_arch = "riscv64"
+))]
+#[allow(asm_sub_register)]
+#[inline]
+pub(crate) fn optimizer_hide(mut value: u8) -> u8 {
+    // SAFETY: the input value is passed unchanged to the output, the inline assembly does nothing.
+    unsafe {
+        core::arch::asm!("/* {0} */", inout(reg) value, options(pure, nomem, nostack, preserves_flags));
+        value
+    }
+}
+
+#[cfg(not(any(
+    target_arch = "x86",
+    target_arch = "x86_64",
+    target_arch = "arm",
+    target_arch = "aarch64",
+    target_arch = "riscv32",
+    target_arch = "riscv64"
+)))]
+#[inline(never)] // This function is non-inline to prevent the optimizer from looking inside it.
+pub(crate) fn optimizer_hide(value: u8) -> u8 {
+    // SAFETY: the result of casting a reference to a pointer is valid; the type is Copy.
+    unsafe { core::ptr::read_volatile(&value) }
+}

--- a/src/imp.rs
+++ b/src/imp.rs
@@ -1,0 +1,111 @@
+use crate::{hide::optimizer_hide, ConstTimeEq};
+
+impl<T: AsRef<[u8]>> ConstTimeEq<T> for &[u8] {
+    #[inline]
+    fn constant_time_ne(&self, other: &T) -> u8 {
+        let other = other.as_ref();
+        assert!(self.len() == other.len());
+
+        // These useless slices make the optimizer elide the bounds checks.
+        // See the comment in clone_from_slice() added on Rust commit 6a7bc47.
+        let len = self.len();
+        let a = &self[..len];
+        let b = &other[..len];
+
+        let mut tmp = 0;
+        for i in 0..len {
+            tmp |= a[i] ^ b[i];
+        }
+
+        // The compare with 0 must happen outside this function.
+        optimizer_hide(tmp)
+    }
+}
+
+// Fixed-size variants for the most common sizes.
+
+macro_rules! constant_time_ne_n {
+    ($n:expr) => {
+        impl ConstTimeEq<[u8; $n]> for [u8; $n] {
+            #[inline]
+            fn constant_time_ne(&self, other: &[u8; $n]) -> u8 {
+                let mut tmp = 0;
+                for i in 0..$n {
+                    tmp |= self[i] ^ other[i];
+                }
+
+                // The compare with 0 must happen outside this function.
+                optimizer_hide(tmp)
+            }
+        }
+    };
+}
+
+constant_time_ne_n!(16);
+constant_time_ne_n!(32);
+constant_time_ne_n!(64);
+
+/// Compares two 128-bit byte strings in constant time.
+///
+/// # Examples
+///
+/// ```
+/// use constant_time_eq::constant_time_eq_16;
+///
+/// assert!(constant_time_eq_16(&[3; 16], &[3; 16]));
+/// assert!(!constant_time_eq_16(&[3; 16], &[7; 16]));
+/// ```
+#[inline]
+pub fn constant_time_eq_16(a: &[u8; 16], b: &[u8; 16]) -> bool {
+    a.constant_time_eq(b)
+}
+
+/// Compares two 256-bit byte strings in constant time.
+///
+/// # Examples
+///
+/// ```
+/// use constant_time_eq::constant_time_eq_32;
+///
+/// assert!(constant_time_eq_32(&[3; 32], &[3; 32]));
+/// assert!(!constant_time_eq_32(&[3; 32], &[7; 32]));
+/// ```
+#[inline]
+pub fn constant_time_eq_32(a: &[u8; 32], b: &[u8; 32]) -> bool {
+    a.constant_time_eq(b)
+}
+
+/// Compares two 512-bit byte strings in constant time.
+///
+/// # Examples
+///
+/// ```
+/// use constant_time_eq::constant_time_eq_64;
+///
+/// assert!(constant_time_eq_64(&[3; 64], &[3; 64]));
+/// assert!(!constant_time_eq_64(&[3; 64], &[7; 64]));
+/// ```
+#[inline]
+pub fn constant_time_eq_64(a: &[u8; 64], b: &[u8; 64]) -> bool {
+    a.constant_time_eq(b)
+}
+
+/// Compares two equal-sized byte strings in constant time.
+///
+/// # Examples
+///
+/// ```
+/// use constant_time_eq::constant_time_eq;
+///
+/// assert!(constant_time_eq(b"foo", b"foo"));
+/// assert!(!constant_time_eq(b"foo", b"bar"));
+/// assert!(!constant_time_eq(b"bar", b"baz"));
+/// # assert!(constant_time_eq(b"", b""));
+///
+/// // Not equal-sized, so won't take constant time.
+/// assert!(!constant_time_eq(b"foo", b""));
+/// assert!(!constant_time_eq(b"foo", b"quux"));
+/// ```
+pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    a.len() == b.len() && a.constant_time_eq(&b)
+}

--- a/src/imp_cg.rs
+++ b/src/imp_cg.rs
@@ -1,0 +1,101 @@
+use crate::{hide::optimizer_hide, ConstTimeEq};
+
+impl<T: AsRef<[u8]>> ConstTimeEq<T> for &[u8] {
+    #[inline]
+    fn constant_time_ne(&self, other: &T) -> u8 {
+        let other = other.as_ref();
+        assert!(self.len() == other.len());
+
+        // These useless slices make the optimizer elide the bounds checks.
+        // See the comment in clone_from_slice() added on Rust commit 6a7bc47.
+        let len = self.len();
+        let a = &self[..len];
+        let b = &other[..len];
+
+        let mut tmp = 0;
+        for i in 0..len {
+            tmp |= a[i] ^ b[i];
+        }
+
+        // The compare with 0 must happen outside this function.
+        optimizer_hide(tmp)
+    }
+}
+
+impl<const SIZE: usize> ConstTimeEq<[u8; SIZE]> for [u8; SIZE] {
+    #[inline]
+    fn constant_time_ne(&self, other: &[u8; SIZE]) -> u8 {
+        let mut tmp = 0;
+        for i in 0..SIZE {
+            tmp |= self[i] ^ other[i];
+        }
+
+        // The compare with 0 must happen outside this function.
+        optimizer_hide(tmp)
+    }
+}
+
+/// Compares two 128-bit byte strings in constant time.
+///
+/// # Examples
+///
+/// ```
+/// use constant_time_eq::constant_time_eq_16;
+///
+/// assert!(constant_time_eq_16(&[3; 16], &[3; 16]));
+/// assert!(!constant_time_eq_16(&[3; 16], &[7; 16]));
+/// ```
+#[inline]
+pub fn constant_time_eq_16(a: &[u8; 16], b: &[u8; 16]) -> bool {
+    a.constant_time_eq(b)
+}
+
+/// Compares two 256-bit byte strings in constant time.
+///
+/// # Examples
+///
+/// ```
+/// use constant_time_eq::constant_time_eq_32;
+///
+/// assert!(constant_time_eq_32(&[3; 32], &[3; 32]));
+/// assert!(!constant_time_eq_32(&[3; 32], &[7; 32]));
+/// ```
+#[inline]
+pub fn constant_time_eq_32(a: &[u8; 32], b: &[u8; 32]) -> bool {
+    a.constant_time_eq(b)
+}
+
+/// Compares two 512-bit byte strings in constant time.
+///
+/// # Examples
+///
+/// ```
+/// use constant_time_eq::constant_time_eq_64;
+///
+/// assert!(constant_time_eq_64(&[3; 64], &[3; 64]));
+/// assert!(!constant_time_eq_64(&[3; 64], &[7; 64]));
+/// ```
+#[inline]
+pub fn constant_time_eq_64(a: &[u8; 64], b: &[u8; 64]) -> bool {
+    a.constant_time_eq(b)
+}
+
+/// Compares two equal-sized byte strings in constant time.
+///
+/// # Examples
+///
+/// ```
+/// use constant_time_eq::constant_time_eq;
+///
+/// assert!(constant_time_eq(b"foo", b"foo"));
+/// assert!(!constant_time_eq(b"foo", b"bar"));
+/// assert!(!constant_time_eq(b"bar", b"baz"));
+/// # assert!(constant_time_eq(b"", b""));
+///
+/// // Not equal-sized, so won't take constant time.
+/// assert!(!constant_time_eq(b"foo", b""));
+/// assert!(!constant_time_eq(b"foo", b"quux"));
+/// ```
+pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    a.len() == b.len() && a.constant_time_eq(&b)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,146 +1,34 @@
 #![no_std]
 
-#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-#[inline]
-fn optimizer_hide(mut value: u8) -> u8 {
-    // SAFETY: the input value is passed unchanged to the output, the inline assembly does nothing.
-    unsafe {
-        core::arch::asm!("/* {0} */", inout(reg_byte) value, options(pure, nomem, nostack, preserves_flags));
-        value
+pub(crate) mod hide;
+#[cfg(not(feature = "const-generics"))]
+mod imp;
+#[cfg(feature = "const-generics")]
+mod imp_cg;
+
+#[cfg(not(feature = "const-generics"))]
+pub use imp::*;
+#[cfg(feature = "const-generics")]
+pub use imp_cg::*;
+
+/// This trait is used to implement a constant time equality checking function.
+/// It is expected that both sides are equal in size.
+///
+/// # Examples
+/// ```rust
+/// use constant_time_eq::ConstantTimeEq;
+///
+/// let x = b"foo";
+/// let y = b"foo";
+/// let z = b"bar";
+/// // These two will take the exact same amount of clock cycles!
+/// assert!(x.constant_time_eq(&y));
+/// assert!(!x.constant_time_eq(&z));
+/// ```
+pub trait ConstTimeEq<Other> {
+    fn constant_time_ne(&self, other: &Other) -> u8;
+    #[inline]
+    fn constant_time_eq(&self, other: &Other) -> bool {
+        self.constant_time_ne(other) == 0
     }
-}
-
-#[cfg(any(
-    target_arch = "arm",
-    target_arch = "aarch64",
-    target_arch = "riscv32",
-    target_arch = "riscv64"
-))]
-#[allow(asm_sub_register)]
-#[inline]
-fn optimizer_hide(mut value: u8) -> u8 {
-    // SAFETY: the input value is passed unchanged to the output, the inline assembly does nothing.
-    unsafe {
-        core::arch::asm!("/* {0} */", inout(reg) value, options(pure, nomem, nostack, preserves_flags));
-        value
-    }
-}
-
-#[cfg(not(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    target_arch = "arm",
-    target_arch = "aarch64",
-    target_arch = "riscv32",
-    target_arch = "riscv64"
-)))]
-#[inline(never)] // This function is non-inline to prevent the optimizer from looking inside it.
-fn optimizer_hide(value: u8) -> u8 {
-    // SAFETY: the result of casting a reference to a pointer is valid; the type is Copy.
-    unsafe { core::ptr::read_volatile(&value) }
-}
-
-#[inline]
-fn constant_time_ne(a: &[u8], b: &[u8]) -> u8 {
-    assert!(a.len() == b.len());
-
-    // These useless slices make the optimizer elide the bounds checks.
-    // See the comment in clone_from_slice() added on Rust commit 6a7bc47.
-    let len = a.len();
-    let a = &a[..len];
-    let b = &b[..len];
-
-    let mut tmp = 0;
-    for i in 0..len {
-        tmp |= a[i] ^ b[i];
-    }
-
-    // The compare with 0 must happen outside this function.
-    optimizer_hide(tmp)
-}
-
-/// Compares two equal-sized byte strings in constant time.
-///
-/// # Examples
-///
-/// ```
-/// use constant_time_eq::constant_time_eq;
-///
-/// assert!(constant_time_eq(b"foo", b"foo"));
-/// assert!(!constant_time_eq(b"foo", b"bar"));
-/// assert!(!constant_time_eq(b"bar", b"baz"));
-/// # assert!(constant_time_eq(b"", b""));
-///
-/// // Not equal-sized, so won't take constant time.
-/// assert!(!constant_time_eq(b"foo", b""));
-/// assert!(!constant_time_eq(b"foo", b"quux"));
-/// ```
-pub fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    a.len() == b.len() && constant_time_ne(a, b) == 0
-}
-
-// Fixed-size variants for the most common sizes.
-
-macro_rules! constant_time_ne_n {
-    ($ne:ident, $n:expr) => {
-        #[inline]
-        fn $ne(a: &[u8; $n], b: &[u8; $n]) -> u8 {
-            let mut tmp = 0;
-            for i in 0..$n {
-                tmp |= a[i] ^ b[i];
-            }
-
-            // The compare with 0 must happen outside this function.
-            optimizer_hide(tmp)
-        }
-    };
-}
-
-constant_time_ne_n!(constant_time_ne_16, 16);
-constant_time_ne_n!(constant_time_ne_32, 32);
-constant_time_ne_n!(constant_time_ne_64, 64);
-
-/// Compares two 128-bit byte strings in constant time.
-///
-/// # Examples
-///
-/// ```
-/// use constant_time_eq::constant_time_eq_16;
-///
-/// assert!(constant_time_eq_16(&[3; 16], &[3; 16]));
-/// assert!(!constant_time_eq_16(&[3; 16], &[7; 16]));
-/// ```
-#[inline]
-pub fn constant_time_eq_16(a: &[u8; 16], b: &[u8; 16]) -> bool {
-    constant_time_ne_16(a, b) == 0
-}
-
-/// Compares two 256-bit byte strings in constant time.
-///
-/// # Examples
-///
-/// ```
-/// use constant_time_eq::constant_time_eq_32;
-///
-/// assert!(constant_time_eq_32(&[3; 32], &[3; 32]));
-/// assert!(!constant_time_eq_32(&[3; 32], &[7; 32]));
-/// ```
-#[inline]
-pub fn constant_time_eq_32(a: &[u8; 32], b: &[u8; 32]) -> bool {
-    constant_time_ne_32(a, b) == 0
-}
-
-/// Compares two 512-bit byte strings in constant time.
-///
-/// # Examples
-///
-/// ```
-/// use constant_time_eq::constant_time_eq_64;
-///
-/// assert!(constant_time_eq_64(&[3; 64], &[3; 64]));
-/// assert!(!constant_time_eq_64(&[3; 64], &[7; 64]));
-/// ```
-#[inline]
-pub fn constant_time_eq_64(a: &[u8; 64], b: &[u8; 64]) -> bool {
-    constant_time_ne_64(a, b) == 0
 }


### PR DESCRIPTION
Now that [inline asm](https://github.com/cesarb/constant_time_eq/commit/b749d4349186d87d5afaa519e88819119a24c83c) is used to hide from the optimizer, the concerns raised in https://github.com/cesarb/constant_time_eq/pull/4 should be resolved.

This takes a different approach from that PR - while it still uses a trait, this should remain *fully backward compatible*, and const generics can even disabled by turning off default features.

[In addition, a basic godbolt test shows identical assembly generation, even at maximum optimization](https://godbolt.org/z/xMvYcxrME)!