### PR TITLE
use the portable optimizer_hide() when running under Miri

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        toolchain: [1.68.0, stable, beta, nightly]
+        toolchain: [1.74.0, stable, beta, nightly]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,24 @@ jobs:
           cargo build --verbose --release --target $TARGET
       - run: cargo test --verbose --release --features count_instructions_test
       - run: cargo bench --verbose
+
+  miri:
+    name: Run tests under Miri
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-nightly-${{ hashFiles('**/Cargo.lock', '**/Cargo.toml') }}
+      - run: rustup toolchain install nightly --profile=minimal --no-self-update
+      - run: rustup default nightly
+      - run: rustup override set nightly
+      - run: rustup component add miri
+      - run: rustc --verbose --version
+      - run: cargo --verbose --version
+      - run: cargo miri test --verbose

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+#[cfg(not(miri))]
 #[inline]
 #[must_use]
 fn optimizer_hide(mut value: u8) -> u8 {
@@ -17,6 +18,7 @@ fn optimizer_hide(mut value: u8) -> u8 {
     target_arch = "riscv32",
     target_arch = "riscv64"
 ))]
+#[cfg(not(miri))]
 #[inline]
 #[must_use]
 #[allow(asm_sub_register)]
@@ -28,14 +30,17 @@ fn optimizer_hide(mut value: u8) -> u8 {
     }
 }
 
-#[cfg(not(any(
-    target_arch = "x86",
-    target_arch = "x86_64",
-    target_arch = "arm",
-    target_arch = "aarch64",
-    target_arch = "riscv32",
-    target_arch = "riscv64"
-)))]
+#[cfg(any(
+    not(any(
+        target_arch = "x86",
+        target_arch = "x86_64",
+        target_arch = "arm",
+        target_arch = "aarch64",
+        target_arch = "riscv32",
+        target_arch = "riscv64",
+    )),
+    miri,
+))]
 #[inline(never)]
 #[must_use]
 fn optimizer_hide(value: u8) -> u8 {


### PR DESCRIPTION
Inspired by [a discussion about `subtle` and `constant_time_eq` earlier today](https://github.com/BLAKE3-team/BLAKE3/pull/419), I wanted to try to make this crate Miri-compatible. The `blake3` crate currently [has its own workaround](https://github.com/BLAKE3-team/BLAKE3/blob/479eef82d756221abe9f93077b91ce8cf763c32a/src/lib.rs#L318-L331) for Miri compatibility, but it might be nice to upstream that for other callers. Let me know what you think.